### PR TITLE
Be More Defensive of Incompatible FROST Keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
-:warning: **Code in this repository is not audited and may contain serious security holes; use at your own risk.** :warning:
+> [!WARNING]
+> Code in this repository is not audited and may contain serious security holes. Use at your own risk.
 
 # Safe + FROST
 
@@ -198,6 +199,10 @@ forge test --ffi
 ```
 
 Note that the tests require `forge` FFI, in order to execute `safe-frost` CLI commands.
+
+### Account Restrictions
+
+The `ecrecover` precompile is specified to only allow recovery IDs (the `v` value) that encode the y-parity of the signature `r` value, and not whether or not `R.x = r + secp256k1.n`. Since we pass in the account's public key as the signature `r` value, we cannot encode accounts with public keys that have x-coordinates that are in the range `[secp256k1.n, secp256k1.p)`. While this is _very_ unlikely (it requires roughly 128 bits of work to find such a key or a ~0.000000000000000000000000000000000000373% chance of occurring, assuming uniform distribution of x-coordinates of secp256k1 points), we added some special logic in the CLI application to not generate groups keys that have unsupported public keys. This limitation should be kept in mind when using other FROST implementations.
 
 ## Prior Art
 

--- a/src/cmd/info.rs
+++ b/src/cmd/info.rs
@@ -1,6 +1,7 @@
 use crate::{
     address::Address,
     cmd::{self, Root},
+    evm,
     fmt::{Coord, Hex, Scalar},
 };
 use argh::FromArgs;
@@ -47,7 +48,7 @@ impl Command {
             Subcommand::PublicKey(_) => {
                 let data = fs::read(root.public_key())?;
                 let key = frost::keys::PublicKeyPackage::deserialize(&data)?;
-                let key = key.verifying_key();
+                let key = evm::verified_public_key(&key)?;
 
                 if self.abi_encode {
                     let mut buf = Vec::new();
@@ -69,7 +70,7 @@ impl Command {
                 } else {
                     None
                 };
-                let key = key.as_ref().map(|key| key.verifying_key());
+                let key = key.as_ref().map(evm::verified_public_key).transpose()?;
 
                 if self.abi_encode {
                     let mut buf = Vec::new();

--- a/src/evm.rs
+++ b/src/evm.rs
@@ -1,0 +1,49 @@
+use frost::{Field as _, Secp256K1ScalarField, VerifyingKey, keys::PublicKeyPackage};
+use k256::elliptic_curve::sec1::ToEncodedPoint as _;
+use std::fmt::{self, Display, Formatter};
+
+/// Verifies whether or not a `secp256k1` public key is valid and supported with
+/// the FROST(secp256k1, SHA-256) EVM verifier implementation.
+///
+/// In particular, public keys with x-coordinates that are higher than the curve
+/// order are not supported. This is because we abuse the `ecrecover` precompile
+/// to compute scalar multiplcation and point addition `-z⋅G + e⋅P` by passing
+/// the public key's `P` x-coordinate as the `ecrecover` signature `r` value.
+/// This "trick" does not support public keys with x-coordinates greater than the
+/// curve order because:
+///
+/// 1. ECDSA signature `r` values are encoded as scalars that must be less than
+///    the curve order.
+/// 2. Ethereum `ecrecover` does not support recovery IDs (the `v` value) that
+///    encode when the signature `R` point encoded in the `r` value has an
+///    x-coordinate of `R.x = r + n` (where `n` is the order of the curve).
+pub fn verified_public_key(key: &PublicKeyPackage) -> Result<&VerifyingKey, NotSupported> {
+    let key = key.verifying_key();
+    let point = key.to_element().to_encoded_point(true);
+    let _ = Secp256K1ScalarField::deserialize(point.as_bytes()[1..].try_into()?)?;
+    Ok(key)
+}
+
+/// An error decoding a hex string.
+#[derive(Debug)]
+pub struct NotSupported;
+
+impl Display for NotSupported {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        f.write_str("public key not supported by the EVM verifier")
+    }
+}
+
+impl From<frost::FieldError> for NotSupported {
+    fn from(_: frost::FieldError) -> Self {
+        NotSupported
+    }
+}
+
+impl From<std::array::TryFromSliceError> for NotSupported {
+    fn from(_: std::array::TryFromSliceError) -> Self {
+        NotSupported
+    }
+}
+
+impl std::error::Error for NotSupported {}

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,6 +3,7 @@
 mod address;
 mod cmd;
 mod data;
+mod evm;
 mod fmt;
 mod hex;
 mod keccak;


### PR DESCRIPTION
Because of how `ecrecover` is implemented, not all FROST public keys are supported by the `ecmulmuladd` trick that we use in our verifier. While the chance of it happening is exceedingly rare (~1/2**128), just to be safe, I modified the CLI to check for key validity for some operations (such as splitting and encoding public key information for account deployment).